### PR TITLE
Corrected URL for downloading Perl src archives

### DIFF
--- a/bin/cpanorg_perl_releases
+++ b/bin/cpanorg_perl_releases
@@ -139,7 +139,7 @@ sub fetch_perl_version_data {
         my $zip_file = $module->{distvname} . '.tar.gz';
 
         $module->{zip_file} = $zip_file;
-        $module->{url} = "http://www.cpan.org/src/" . $module->{zip_file};
+        $module->{url} = "http://www.cpan.org/src/5.0/" . $module->{zip_file};
 
         ( $module->{released_date}, $module->{released_time} )
             = split( 'T', $module->{released} );


### PR DESCRIPTION
The URLs on the src/README file were 404'ing - looks like the src tar files have moved to src/5.0/....
