### PR TITLE
Small link fix

### DIFF
--- a/src/ports/index.html
+++ b/src/ports/index.html
@@ -29,7 +29,7 @@
 
     <li>Running a version older than 5.8.3? - some of the more widely used CPAN modules now require at least this version.
     </li>
-    <li>You can build your own version of Perl from the <a href="src/">
+    <li>You can build your own version of Perl from the <a href="/src/">
         source code</a>!
     </li>
 </ul>


### PR DESCRIPTION
The link to the source page in ports/index.html is a relative link. It needs to go one level up to src/.
