### PR TITLE
Make it easier to find how to contribute to the CPAN

### DIFF
--- a/src/_modules/index.html
+++ b/src/_modules/index.html
@@ -72,7 +72,7 @@
                 How to contribute
             </h2>
             <ul>
-                <li>Read <a href="04pause.html">this</a>
+                <li>Read <a href="/modules/04pause.html">this</a>
                 </li>
                 <li>Visit <a href=
                 "https://pause.perl.org/">https://pause.perl.org/</a>

--- a/src/index.html
+++ b/src/index.html
@@ -109,7 +109,7 @@
                 How to contribute
             </h2>
             <ul>
-                <li>Read <a href="04pause.html">this</a>
+                <li>Read <a href="/modules/04pause.html">this</a>
                 </li>
                 <li>Visit <a href=
                 "https://pause.perl.org/">https://pause.perl.org/</a>

--- a/src/index.html
+++ b/src/index.html
@@ -105,6 +105,17 @@
                 <li><a href="http://learn.perl.org/">Learn Perl</a></li>
             </ul>
 
+            <h2>
+                How to contribute
+            </h2>
+            <ul>
+                <li>Read <a href="04pause.html">this</a>
+                </li>
+                <li>Visit <a href=
+                "https://pause.perl.org/">https://pause.perl.org/</a>
+                </li>
+            </ul>
+
             <h2>Perl Resources</h2>
             <ul>
                 <li><a href="http://www.perl.org/">The Perl Programming language</a></li>


### PR DESCRIPTION
This copies a section of http://www.cpan.org/modules/index.html to http://www.cpan.org/modules/, and also updates them both to link to /modules/04pause.html so that they're consistent. It might be better to refactor and cut out the shared content into another file and [% INCLUDE %] it into place.