### PR TITLE
Use HTTPS when generating links to the Perl source

### DIFF
--- a/bin/cpanorg_perl_releases
+++ b/bin/cpanorg_perl_releases
@@ -147,7 +147,7 @@ sub fetch_perl_version_data {
         my $zip_file = $module->{distvname} . '.tar.gz';
 
         $module->{zip_file} = $zip_file;
-        $module->{url} = "http://www.cpan.org/src/5.0/" . $module->{zip_file};
+        $module->{url} = "https://www.cpan.org/src/5.0/" . $module->{zip_file};
 
         ( $module->{released_date}, $module->{released_time} )
             = split( 'T', $module->{released} );


### PR DESCRIPTION
We can't dynamically swap between HTTP and HTTPS in a static page. We could use
the protocol-agnostic URL method (e.g. //www.cpan.org/...) but it's now
considered an anti-pattern:

https://www.paulirish.com/2010/the-protocol-relative-url/
https://jeremywagner.me/blog/stop-using-the-protocol-relative-url/

...so let's just default to HTTPS.