### PR TITLE
Fix link to "modules/04pause.html"

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -108,7 +108,7 @@
                 How to contribute
             </h2>
             <ul>
-                <li>Read <a href="/modules/04pause.html">this</a>
+                <li>Read <a href="modules/04pause.html">this</a>
                 </li>
                 <li>Visit <a href=
                 "https://pause.perl.org/">https://pause.perl.org/</a>


### PR DESCRIPTION
This link doesn't work on mirrors that don't have CPAN at "/".