### PR TITLE
Fix Perl version parsing for latest releases list

### DIFF
--- a/bin/cpanorg_perl_releases
+++ b/bin/cpanorg_perl_releases
@@ -122,14 +122,20 @@ sub fetch_perl_version_data {
     my @perls;
     my @testing;
     foreach my $module ( @{ $data->{releases} } ) {
-        next unless $module->{authorized} eq 'true';
+        next unless $module->{authorized};
 
         my $version = $module->{version};
 
         $version =~ s/-(?:RC|TRIAL)\d+$//;
         $module->{version_number} = $version;
 
-        my ( $major, $minor, $iota ) = split( '[\._]', $version );
+        my ( $major, $minor, $iota ) = split( /[\._]/, $version );
+        # If we get a version like 5.010001, we need to split up the decimal
+        # component in groups of 3 digits
+        if ( !defined $iota ) {
+            $minor .= '0'x(6 - length $minor) if length $minor < 6;
+            $iota = substr $minor, 3, 3, '';
+        }
         $module->{version_major} = $major;
         $module->{version_minor} = int($minor);
         $module->{version_iota}  = int( $iota || '0' );


### PR DESCRIPTION
The latest releases list at https://www.cpan.org/src/README.html is not showing Perl versions correctly. It seems to be that the versions now returned by the API are in a different format than expected - they are returned in the format '5.XXXYYY'. This adds logic so that if the version only had one separator, the second component will be 0-padded to 6 digits and then split to populate minor and iota.

Also removed the string comparison with 'true' for determining authorized status, since most JSON booleans do not stringify to 'true'.