### PR TITLE
Fix perl releases API parsing for older releases

### DIFF
--- a/bin/cpanorg_perl_releases
+++ b/bin/cpanorg_perl_releases
@@ -8,6 +8,7 @@ use warnings;
 use JSON ();
 use LWP::Simple qw(get);
 use File::Slurp qw(read_file);
+use version 0.77;
 
 my $json = JSON->new->pretty;
 
@@ -122,26 +123,18 @@ sub fetch_perl_version_data {
     my @perls;
     my @testing;
     foreach my $module ( @{ $data->{releases} } ) {
+        next unless $module->{distvname} =~ m/^perl-?v?[\d._]+(-(RC|TRIAL)\d*)?$/;
         next unless $module->{authorized};
 
         my $version = $module->{version};
-
-        $version =~ s/-(?:RC|TRIAL)\d+$//;
         $module->{version_number} = $version;
+        my $version_obj = version->parse($version);
 
-        my ( $major, $minor, $iota ) = split( /[\._]/, $version );
-        # If we get a version like 5.010001, we need to split up the decimal
-        # component in groups of 3 digits
-        if ( !defined $iota ) {
-            $minor .= '0'x(6 - length $minor) if length $minor < 6;
-            $iota = substr $minor, 3, 3, '';
-        }
+        my ( $major, $minor, $iota ) = @{ $version_obj->{version} };
+        next if $major < 5;
         $module->{version_major} = $major;
         $module->{version_minor} = int($minor);
         $module->{version_iota}  = int( $iota || '0' );
-
-        # Do not trust the API as it gets it wrong
-        delete $module->{latest};
 
         $module->{type}
             = $module->{status} eq 'testing'
@@ -150,15 +143,13 @@ sub fetch_perl_version_data {
 
         # TODO: Ask - please add some validation logic here
         # so that on live it checks this exists
-        my $zip_file = $module->{distvname} . '.tar.gz';
+        my $zip_file = $module->{archive};
 
         $module->{zip_file} = $zip_file;
         $module->{url} = "https://www.cpan.org/src/5.0/" . $module->{zip_file};
 
         ( $module->{released_date}, $module->{released_time} )
             = split( 'T', $module->{released} );
-
-        next if $major < 5;
 
         if ( $module->{status} eq 'stable' ) {
             push @perls, $module;


### PR DESCRIPTION
From https://github.com/metacpan/metacpan-api/pull/928 the API being used here for cpanorg_perl_releases should now contain older releases that were missing due to the limited output. This exposed some edge cases that these fixes are meant to handle.

First, we ignore any releases with a release name we don't expect because there's some weird ones that aren't actually releases of perl. Second we parse and split the version field with version.pm because it will now always be a valid Perl version and version.pm knows how to parse either format of that correctly (it was misparsing with a leading v and this makes the heuristic unnecessary). Finally the archive name is available as archive and doesn't need to be constructed anymore, and there is no 'latest' field in the releases anymore.