### PR TITLE
FAQ - Remove mention of obsolete module list, mention Task::Kensho instead

### DIFF
--- a/src/misc/cpan-faq.html
+++ b/src/misc/cpan-faq.html
@@ -447,17 +447,16 @@
 </h3>
 <ul>
     <li>
-        <a href=
-        "http://www.cpan.org/modules/00modlist.long.html">http://www.cpan.org/modules/00modlist.long.html</a>
+        <a href="https://metacpan.org/">https://metacpan.org/</a>
     </li>
     <li>
-        <a href="https://metacpan.org/">https://metacpan.org/</a>
+        <a href="https://metacpan.org/pod/Task::Kensho">Task::Kensho</a>
     </li>
 </ul>
 <p>
-    Due to the ever increasing number of modules on CPAN, the CPAN search
-    engine is possibly a better starting point in your quest for code,
-    especially if you already know exactly what you are looking for.
+    The MetaCPAN search engine is usually the best starting point in your
+    quest for code. Task::Kensho provides a curated set of recommended
+    modules for various tasks.
 </p>
 <hr>
 <h3>


### PR DESCRIPTION
The modulelist is no longer used. Task::Kensho seems worth mentioning in this context.