### PR TITLE
FAQ - Remove mention of obsolete scripts repository

### DIFF
--- a/src/misc/cpan-faq.html
+++ b/src/misc/cpan-faq.html
@@ -739,14 +739,10 @@ spells all this out for your protection, so you may prefer to use that.
 </h3>
 <ul>
     <li>
-        <a href=
-        "http://www.cpan.org/scripts/index.html">http://www.cpan.org/scripts/index.html</a>
+        <a href="https://metacpan.org/">MetaCPAN results include scripts</a>
     </li>
     <li>
-        <a href="http://www.perlarchive.com/">http://www.perlarchive.com/</a>
-    </li>
-    <li>
-        <a href="http://freshmeat.net">http://freshmeat.net/</a>
+        <a href="https://metacpan.org/search?q=App%3A%3A">The App:: namespace</a>
     </li>
     <li>and many, many other places on the net have Perl programs....
     </li>
@@ -1004,10 +1000,9 @@ spells all this out for your protection, so you may prefer to use that.
     contribute scripts to CPAN?</a>
 </h3>
 <p>
-    CPAN has a scripts repository at <a href=
-    "http://www.cpan.org/scripts/">http://www.cpan.org/scripts/</a> and
-    <a href="http://www.cpan.org/scripts/submitting.html">http://www.cpan.org/scripts/submitting.html</a>
-    will instruct you on how to go about contributing your scripts.
+    Scripts can be provided in any CPAN distribution, though distributions
+    need to contain a module to be easily installable. By convention, CPAN
+    modules meant to install scripts are usually put in the App:: namespace.
 </p>
 <hr>
 <h3>


### PR DESCRIPTION
The scripts repository/folder on CPAN is no longer used, so instead mention how they can be distributed and found in standard CPAN distributions. The other mentioned "script" repositories probably don't need to be specifically listed and expose people to their also wildly outdated content.