### PR TITLE
Update ubuntu.tt_data

### DIFF
--- a/src/ports/oses/ubuntu.tt_data
+++ b/src/ports/oses/ubuntu.tt_data
@@ -14,7 +14,7 @@
         kernel => 'linux',
 
         # When was this file last reviewed?
-        information_last_verified => '2017-10-04',
+        information_last_verified => '2021-06-19',
     }
 %]
 
@@ -31,6 +31,48 @@
 
 [% PROCESS version_view os_versions => {
     versions => [
+    {
+        os_name => 'Hirsute Hippo',
+        os_version => '21.04',
+        perl_version => '5.32.1'
+        os_release => '2021-04-22',
+    },
+    {
+        os_name => 'Groovy Gorilla',
+        os_version => '20.10',
+        perl_version => '5.30.3'
+        os_release => '2020-10-22',
+    },
+    {
+        os_name => 'Focal Fossa',
+        os_version => '20.04',
+        perl_version => '5.30.0'
+        os_release => '2020-04-23',
+    },
+    {
+        os_name => 'Eoan Ermine',
+        os_version => '19.10',
+        perl_version => '5.28.1'
+        os_release => '2019-10-17',
+    },
+    {
+        os_name => 'Disco Dingo',
+        os_version => '19.04',
+        perl_version => '5.28.1'
+        os_release => '2019-04-18',
+    },
+    {
+        os_name => 'Cosmic Cuttlefish',
+        os_version => '18.10',
+        perl_version => '5.26.2'
+        os_release => '2018-10-18',
+    },
+    {
+        os_name => 'Bionic Beaver',
+        os_version => '18.04',
+        perl_version => '5.26.1'
+        os_release => '2018-04-26',
+    },
     {
         os_name => 'Artful Aardvark',
         os_version => '17.10',


### PR DESCRIPTION
Hi! I've seen @briandfoy's MR #52, and [his call](https://twitter.com/briandfoy_perl/status/1405483611571298313) for an Ubuntu update, so here I am.

While I'm not running Ubuntu at this time, I used docker to figure out which version is shipped as default. I've come up with command below to make things easier:

```bash
for number in 18.04 18.10 19.04 19.10 20.04 20.10 21.04;\
do docker run ubuntu:$number bash -c "grep PRETTY_NAME /etc/os-release && perl -E 'say $^V'";\
done
```

Upon running, it outputs this (once you have all images locally, otherwise it will also output a whole bunch of other stuff)

```
PRETTY_NAME="Ubuntu 18.04.5 LTS"
v5.26.1
PRETTY_NAME="Ubuntu 18.10"
v5.26.2
PRETTY_NAME="Ubuntu 19.04"
v5.28.1
PRETTY_NAME="Ubuntu 19.10"
v5.28.1
PRETTY_NAME="Ubuntu 20.04.2 LTS"
v5.30.0
PRETTY_NAME="Ubuntu 20.10"
v5.30.3
PRETTY_NAME="Ubuntu 21.04"
v5.32.1
```

I pulled other pieces of data from [Ubuntu version history page in Wikipedia](https://en.wikipedia.org/wiki/Ubuntu_version_history). Feel free to let me know if you want any part of this MR changed. Hope you find this helpful!

Have a great weekend,