### PR TITLE
`cpan.html`: Links and Year corrections

### DIFF
--- a/lib/style/cpan.html
+++ b/lib/style/cpan.html
@@ -6,7 +6,7 @@
     [%- IF page.description %]<meta name="description" content="[% page.description %]" />[% END -%]
     [%- IF page.keywords %]<meta name="keywords" content="[% page.keywords %]" />[% END -%]
     <link rel="author" href="mailto:cpan+linkrelauthor@perl.org" />
-	<link rel="canonical" href="http://www.cpan.org/[% page.canonical || template.name %]" />
+	<link rel="canonical" href="https://www.cpan.org/[% page.canonical || template.name %]" />
 	<link type="text/css" rel="stylesheet" href="[% page.stub %]misc/css/cpan.css" />
     <meta name="viewport" content="width=device-width, initial-scale=1">
 	[% page.head %]
@@ -74,7 +74,7 @@
             <div id="footer_copyright">
                 <p>Yours Eclectically, The Self-Appointed Master Librarians (<i>OOK!</i>) of the CPAN.<br/>
                    &copy; 1995-2010 Jarkko Hietaniemi.
-                   &copy; 2011-2023 <a href="http://www.perl.org">Perl.org</a>.
+                   &copy; 2011-2024 <a href="https://www.perl.org">Perl.org</a>.
                    All rights reserved.
                    <a href="[% page.stub %]disclaimer.html">Disclaimer</a>.
                 </p>
@@ -82,7 +82,7 @@
 
             [% UNLESS page.skip_master_mirror %]
             <div id="footer_mirror">
-			<p>Master mirror hosted by <a href="http://www.netactuate.com/"><img class="netactuate" alt="NetActuate"
+			<p>Master mirror hosted by <a href="https://www.netactuate.com/"><img class="netactuate" alt="NetActuate"
                 height="49" width="149" src="[% page.stub %]misc/images/netactuate.png" /></a>
             and
             <a href="https://www.fastly.com/"><img alt="Fastly" height="49" width="118"


### PR DESCRIPTION
Few minor corrections the cpan.org footer

![image](https://github.com/perlorg/cpanorg/assets/68062695/28b407ee-2c53-426d-931f-889cfea177b7)
