### PR TITLE
`doc/index.html`: Links

### DIFF
--- a/src/doc/index.html
+++ b/src/doc/index.html
@@ -17,12 +17,12 @@
             <ul>
                 <li>
                     <a href=
-                    "http://perldoc.perl.org/">http://perldoc.perl.org/</a> -
+                    "https://perldoc.perl.org/">perldoc.perl.org</a> -
                     core
                 </li>
                 <li>
                     <a href=
-                    "https://metacpan.org/">https://metacpan.org/</a> -
+                    "https://metacpan.org/">metacpan.org</a> -
                     modules
                 </li>
             </ul>
@@ -49,7 +49,7 @@
             </h2>
             <ul>
                 <li>
-                    <a href="http://learn.perl.org/faq/">Perl FAQ</a>
+                    <a href="https://learn.perl.org/faq/">Perl FAQ</a>
                 </li>
                 <li>
                     <a href="../misc/cpan-faq.html">CPAN FAQ</a>
@@ -60,14 +60,14 @@
             </h2>
             <ul>
                 <li>
-                    <a href="http://www.perl.org/">www.perl.org</a>
+                    <a href="https://www.perl.org/">www.perl.org</a>
                 </li>
                 <li>
-                    <a href="http://lists.perl.org/">lists.perl.org</a> -
+                    <a href="https://lists.perl.org/">lists.perl.org</a> -
                     mailing lists
                 </li>
                 <li>
-                    <a href="http://learn.perl.org/">learn.perl.org</a>
+                    <a href="https://learn.perl.org/">learn.perl.org</a>
                 </li>
             </ul>
         </td>


### PR DESCRIPTION
https://www.cpan.org/doc/

remove schema from anchor values to
make consistent with "Other useful sites" section