### PR TITLE
Fix broken "iim" link on how-to-mirror.html

### DIFF
--- a/src/misc/how-to-mirror.html
+++ b/src/misc/how-to-mirror.html
@@ -195,7 +195,7 @@ C:\Program Files\Rsync\rsync -av --delete cpan-rsync.perl.org::CPAN /project/CPA
     guide</a> for more details.
 </p>
 <p>
-    <a href="http://www.staff.science.uu.nl/~penni101/iim">"iim"</a> is an
+    <a href="https://svn.science.uu.nl/repos/sci.penni101.iim/trunk/iim.html">"iim"</a> is an
     alternative for "rrr-client" ; basically it does the same thing, but it is
     more efficient (on start-up) and has some features that may be helpful to
     CPAN mirror operators.


### PR DESCRIPTION
The last successful copy archived by the Wayback Machine was in 2018:
https://web.archive.org/web/20180212054346/http://www.staff.science.uu.nl/~penni101/iim/

The author of the software [passed away a year later](https://www.apache.org/memorials/henk_penning.html).