### PR TITLE
README: Update URL for parrot.

### DIFF
--- a/src/src/README.html
+++ b/src/src/README.html
@@ -170,7 +170,7 @@
         <p>
             Perl 6 or Parrot are not yet in CPAN. In the meanwhile, try
             <a href="http://dev.perl.org/perl6/">here</a> or <a href=
-            "http://www.parrotcode.org/">here</a>.
+            "http://www.parrot.org/">here</a>.
         </p>
     </li>
     <li>


### PR DESCRIPTION
The site for parrot has been moved to http://www.parrot.org/ instead of http://www.parrotcode.org/ for a long time. The internet archive shows that the 301 redirection persisted till September, 2024, before the domain parrotcode.org expired in December 2024.